### PR TITLE
Fix filter reporting in data table

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,13 @@ filter.  This enables tests of the sensitivity of the flux calibration
 to changes in the jwst pipeline or any of the steps in the flux calibration
 factor calculation.
 
+Citation
+--------
+
+The results of this work are published in
+`Gordon et al. 2025, AJ, 169, 6 <https://ui.adsabs.harvard.edu/abs/2025AJ....169....6G>`_.
+Please cite this paper if this repository is used.
+
 Contributors
 ------------
 Karl Gordon

--- a/aper_one_filter.py
+++ b/aper_one_filter.py
@@ -35,6 +35,7 @@ from photutils.aperture import (
 
 def aper_image(
     filename,
+    filter,
     aprad,
     annrad,
     apcor,
@@ -59,7 +60,10 @@ def aper_image(
         targname = "10 Lac"
     elif targname == "HR 6538":
         targname = "HD 159222"
-    filter = hdul[0].header["FILTER"]
+    # filter = hdul[0].header["FILTER"]
+    # can be incorrect in the header as for coronagraphy and FND,
+    # set to the nearest imaging filter to get the pipeline to run image3
+    # as image3 not normally run for those filters
     if "PHOTMJSR" in hdul[1].header.keys():
         photmjysr = hdul[1].header["PHOTMJSR"]
     else:
@@ -399,6 +403,7 @@ def aper_one_filter(subdir, filter, bkgsub=False, eefraction=0.7, indivmos=False
 
         one_res = aper_image(
             cfile,
+            filter,
             aprad,
             annrad,
             apcor,

--- a/pipeline_all_repeat
+++ b/pipeline_all_repeat
@@ -9,6 +9,5 @@ for CBAND in F560W F770W F1000W F1130W F1280W F1500W F1800W F2100W F2550W
 
 do
     python pipeline_one_filter.py --filter=$CBAND --dir=ADwarfs --stage=$FSTAGE --onlynew $EXTOPT
-
     python pipeline_one_filter.py --filter=$CBAND --dir=ADwarfs --stage=stage3 --bkgsub $EXTOPT_BKGSUB
 done


### PR DESCRIPTION
For the coronagraphic and FND filters, the filter reported in the electronic data table was incorrect.  The filter reported was that closest imaging filter that was used to run image3.  A straightforward correction that does not affect anything expect the electronic datatable.

Also adding in the reference to the published paper to the ReadMe.